### PR TITLE
companiesテーブルをteamsテーブルに変更する

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,2 +1,0 @@
-class Company < ApplicationRecord
-end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,2 @@
+class Team < ApplicationRecord
+end

--- a/db/migrate/20220101020854_create_teams.rb
+++ b/db/migrate/20220101020854_create_teams.rb
@@ -1,4 +1,4 @@
-class CreateCompanies < ActiveRecord::Migration[6.1]
+class CreateTeams < ActiveRecord::Migration[6.1]
   def change
     create_table :teams do |t|
       t.string :name, null: false

--- a/db/migrate/20220101020854_create_teams.rb
+++ b/db/migrate/20220101020854_create_teams.rb
@@ -1,6 +1,6 @@
 class CreateCompanies < ActiveRecord::Migration[6.1]
   def change
-    create_table :companies do |t|
+    create_table :teams do |t|
       t.string :name #, null: false
       t.string :phone_number #, null: false
       t.string :email #, null: false

--- a/db/migrate/20220101020854_create_teams.rb
+++ b/db/migrate/20220101020854_create_teams.rb
@@ -1,9 +1,8 @@
 class CreateCompanies < ActiveRecord::Migration[6.1]
   def change
     create_table :teams do |t|
-      t.string :name #, null: false
-      t.string :phone_number #, null: false
-      t.string :email #, null: false
+      t.string :name, null: false
+      t.text :remarks
 
       t.timestamps
     end

--- a/db/migrate/20220101023455_devise_create_users.rb
+++ b/db/migrate/20220101023455_devise_create_users.rb
@@ -35,7 +35,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       t.string :name, null: false
       t.string :phone_number, null: false
       t.string :nickname, null: false
-      t.references :company
+      t.references :team
 
       t.timestamps null: false
     end

--- a/db/migrate/20220101040928_create_groupings.rb
+++ b/db/migrate/20220101040928_create_groupings.rb
@@ -1,7 +1,7 @@
 class CreateGroupings < ActiveRecord::Migration[6.1]
   def change
     create_table :groupings do |t|
-      t.references :company, null: false, foreign_key: true
+      t.references :team, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20220103044705_create_products.rb
+++ b/db/migrate/20220103044705_create_products.rb
@@ -5,8 +5,8 @@ class CreateProducts < ActiveRecord::Migration[6.1]
       t.string :name, null: false
       t.text :remarks
       t.integer :regular_price
-      t.numeric :selling_price
-      t.numeric :cost_price
+      t.float :selling_price
+      t.float :cost_price
       t.references :user, null: false, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,20 +45,12 @@ ActiveRecord::Schema.define(version: 2022_01_07_105322) do
     t.index ["code"], name: "index_clients_on_code", unique: true
   end
 
-  create_table "companies", force: :cascade do |t|
-    t.string "name"
-    t.string "phone_number"
-    t.string "email"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "groupings", force: :cascade do |t|
-    t.bigint "company_id", null: false
+    t.bigint "team_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["company_id"], name: "index_groupings_on_company_id"
+    t.index ["team_id"], name: "index_groupings_on_team_id"
     t.index ["user_id"], name: "index_groupings_on_user_id"
   end
 
@@ -67,8 +59,8 @@ ActiveRecord::Schema.define(version: 2022_01_07_105322) do
     t.string "name", null: false
     t.text "remarks"
     t.integer "regular_price"
-    t.decimal "selling_price"
-    t.decimal "cost_price"
+    t.float "selling_price"
+    t.float "cost_price"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -88,6 +80,13 @@ ActiveRecord::Schema.define(version: 2022_01_07_105322) do
     t.index ["code"], name: "index_suppliers_on_code", unique: true
   end
 
+  create_table "teams", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "remarks"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -102,17 +101,17 @@ ActiveRecord::Schema.define(version: 2022_01_07_105322) do
     t.string "name", null: false
     t.string "phone_number", null: false
     t.string "nickname", null: false
-    t.bigint "company_id"
+    t.bigint "team_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["company_id"], name: "index_users_on_company_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["nickname"], name: "index_users_on_nickname", unique: true
     t.index ["phone_number"], name: "index_users_on_phone_number", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["team_id"], name: "index_users_on_team_id"
   end
 
-  add_foreign_key "groupings", "companies"
+  add_foreign_key "groupings", "teams"
   add_foreign_key "groupings", "users"
   add_foreign_key "products", "users"
 end

--- a/test/fixtures/groupings.yml
+++ b/test/fixtures/groupings.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  company: one
+  team: one
   user: one
 
 two:
-  company: two
+  team: two
   user: two

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class CompanyTest < ActiveSupport::TestCase
+class TeamTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end


### PR DESCRIPTION
close #17

- rails db:drop
- company, companiesを検索しteam, teamsに変更
- teamsテーブルのカラムを変更
- productsテーブルのnumeric型をfloat型に変更
- 外部キーで、コメントアウトにしていたものを解除
- rails db:create
- rails db:migrate