### PR TITLE
仕入機能で商品×個数(purchase_detail)の削除と編集ができるようにする

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,5 +1,6 @@
 class PurchasesController < ApplicationController
   before_action :set_purchase, only: %i[ edit update destroy ]
+  before_action :set_purchase_detail, only: %i[ detail_destroy ]
 
   def index
     @purchases = Purchase.all # .order(created_at: :desc)
@@ -43,6 +44,11 @@ class PurchasesController < ApplicationController
     redirect_to purchases_path, notice: "仕入を削除しました！"
   end
 
+  def detail_destroy
+    @purchase_detail.destroy
+    redirect_to purchases_path, notice: "仕入を削除しました！"
+  end
+
   private
   def set_purchase
     @purchase = Purchase.find(params[:id])
@@ -50,5 +56,13 @@ class PurchasesController < ApplicationController
 
   def purchase_params
     params.require(:purchase).permit(:code, :date_at, :inputter, :supplier_id, purchase_details_attributes: [:id, :product_id, :quantity])
+  end
+
+  def set_purchase_detail
+    @purchase_detail = PurchaseDetail.find(params[:purchase_detail_id])
+  end
+
+  def purchase_detail_params
+    params.require(:purchase_detail).permit(:quantity, :purchase_id, :product_id)
   end
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -32,7 +32,7 @@ class PurchasesController < ApplicationController
   end
 
   def update    
-    if @purchase.update(purchase_params)
+    if @purchase.update!(purchase_params)
       redirect_to edit_purchase_path(@purchase.id), notice: "仕入を編集しました！"
     else
       render :edit
@@ -46,7 +46,7 @@ class PurchasesController < ApplicationController
 
   def detail_destroy
     @purchase_detail.destroy
-    redirect_to purchases_path, notice: "仕入を削除しました！"
+    redirect_to edit_purchase_path(@purchase.id), notice: "商品を削除しました！"
   end
 
   private

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3,7 +3,16 @@ class Purchase < ApplicationRecord
   belongs_to :user
   has_many :purchase_details, dependent: :destroy
   has_many :purchased_products, through: :purchase_details, source: :product
-  accepts_nested_attributes_for :purchase_details, allow_destroy: true
+  accepts_nested_attributes_for :purchase_details,
+                                 reject_if: :reject_purchase_details,
+                                 allow_destroy: true
   validates :date_at,  presence: true
   validates :inputter,  presence: true
+
+  def reject_purchase_details(attributes)
+    exists = attributes[:product_id].present?
+    empty = attributes[:quantity].blank?
+    attributes.merge!(_destroy: 1) if exists && empty
+    !exists && empty
+  end
 end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -6,5 +6,5 @@ class Supplier < ApplicationRecord
   validates :phone_number, length: { maximum: 20 }
   validates :fax_number, length: { maximum: 20 }
   validates :address, length: { maximum: 40 }
-  validates :remaks, length: { maximum: 400 }
+  validates :remarks, length: { maximum: 400 }
 end

--- a/app/views/purchases/_form.html.erb
+++ b/app/views/purchases/_form.html.erb
@@ -47,6 +47,16 @@
       <%= pd.object.product.regular_price.to_i.to_s(:delimited) if pd.object.id.present? %>
     </div>
 
+    <% if pd.object.id.present? %>
+      <div class="detail_total">
+        <%= pd.label :商品合計 %>
+        <%= pd.object.quantity * pd.object.product.cost_price %>
+      </div>
+    <% end %>
+
+    <% if action_name != "new" && !pd.object.id.nil? %>
+      <%= link_to "商品#{pd.index+1}を削除", detail_destroy_purchase_path(purchase_detail_id: pd.object.id), method: :delete %>
+    <% end %>
   <% end %>
   
   <div class="total_amount">

--- a/app/views/purchases/_form.html.erb
+++ b/app/views/purchases/_form.html.erb
@@ -67,5 +67,4 @@
   <%= form.submit %>
 <% end %>
 
-<%= link_to '仕入一覧', purchases_path %>
 <%= link_to 'メインメニュー', menus_path %>

--- a/app/views/purchases/_form.html.erb
+++ b/app/views/purchases/_form.html.erb
@@ -50,7 +50,7 @@
     <% if pd.object.id.present? %>
       <div class="detail_total">
         <%= pd.label :商品合計 %>
-        <%= pd.object.quantity * pd.object.product.cost_price %>
+        <%= (pd.object.quantity * pd.object.product.cost_price).to_i.to_s(:delimited) %>
       </div>
     <% end %>
 

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -1,3 +1,4 @@
 <h2>仕入編集</h2>
 <%= link_to '新規登録', new_purchase_path %>
+<%= link_to '仕入一覧', purchases_path %>
 <%= render 'form' %>

--- a/app/views/purchases/new.html.erb
+++ b/app/views/purchases/new.html.erb
@@ -1,2 +1,3 @@
 <h2>仕入登録</h2>
+<%= link_to '仕入一覧', purchases_path %>
 <%= render 'form' %>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -41,7 +41,7 @@
                         <div class="col-lg-10 col-xl-7">
                             <div class="text-center">
                             <div class="fs-4 mb-4 fst-italic">商品を販売する。</div>
-                                <div class="fs-4 mb-4 fst-italic">"手元にある在庫を管理したいけど、大げさなシステムは必要ない"</div>
+                                <div class="fs-4 mb-4 fst-italic">"手元にある在庫を管理したいけど、大きなシステムは必要ない"</div>
                                 <div class="fs-4 mb-4 fst-italic">そんなときにお使いいただけます。</div>
                             </div>
                         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Rails.application.routes.draw do
   get '/menus', to: 'menus#index' # 「get 'menus/index'」-> menus_index_pathになる
   get 'stocks/show'
 
-  resources :purchases
+  resources :purchases do
+    member do
+      delete 'detail_destroy'
+    end
+  end
   resources :sales
 
   resources :teams do


### PR DESCRIPTION
close #48 

- PurchaseControllerにpurchase_detailを削除するdetail_destroyアクションを新たに作成する
- 商品×個数(purchase_detail)の金額を表示
- 仕入一覧リンクの設置場所を上に移動